### PR TITLE
Probabilistic PCA

### DIFF
--- a/scvid/module/__init__.py
+++ b/scvid/module/__init__.py
@@ -1,0 +1,3 @@
+from ._probabilisticpca import ProbabilisticPCAPyroModule
+
+__all__ = ["ProbabilisticPCAPyroModule"]

--- a/scvid/module/_probabilisticpca.py
+++ b/scvid/module/_probabilisticpca.py
@@ -17,7 +17,7 @@ class ProbabilisticPCAPyroModel(PyroModule):
         n_vars: Number of input features.
         n_components: Number of components to model.
         mean: Mean of the input data.
-        marginalize_z: Marginalize latent variable z.
+        marginalize_z: Marginalize out latent variable z.
     """
 
     def __init__(
@@ -79,7 +79,7 @@ class ProbabilisticPCAPyroGuide(PyroModule):
         n_vars: Number of input features.
         n_components: Number of components to model.
         mean: Mean of the input data.
-        marginalize_z: Marginalize latent variable z.
+        marginalize_z: Marginalize out latent variable z.
     """
 
     def __init__(
@@ -122,7 +122,7 @@ class ProbabilisticPCAPyroModule(PyroBaseModuleClass):
         n_vars: Number of input features.
         n_components: Number of components to model.
         mean: Mean of the input data.
-        marginalize_z: Marginalize latent variable z.
+        marginalize_z: Marginalize out latent variable z.
     """
 
     def __init__(

--- a/scvid/module/_probabilisticpca.py
+++ b/scvid/module/_probabilisticpca.py
@@ -164,6 +164,12 @@ class ProbabilisticPCAPyroModule(PyroBaseModuleClass):
         """
         Return the latent representation for each cell.
         """
-        L = self._guide.L
+        if self.marginalize_z:
+            W = self._model.W
+            sigma = self._model.sigma
+            M = W @ W.T + sigma**2 * torch.eye(len(W))
+            L = W.T @ torch.linalg.inv(M)
+        else:
+            L = self._guide.L
         z_loc = (x - self.mean) @ L
         return z_loc

--- a/scvid/module/_probabilisticpca.py
+++ b/scvid/module/_probabilisticpca.py
@@ -1,0 +1,169 @@
+import pyro
+import pyro.distributions as dist
+import torch
+from pyro.nn import PyroModule, PyroParam
+from scvi.module.base import PyroBaseModuleClass
+from torch.distributions import constraints
+
+_PROBABILISTIC_PCA_PYRO_MODULE_NAME = "probabilistic_pca"
+
+
+class ProbabilisticPCAPyroModel(PyroModule):
+    """
+    A PyroModule that serves as the model for the ProbabilisticPCAPyroModule class.
+
+    Args:
+        n_obs: Number of observations.
+        n_vars: Number of input features.
+        n_components: Number of components to model.
+        mean: Mean of the input data.
+        marginalize_z: Marginalize latent variable z.
+    """
+
+    def __init__(
+        self,
+        n_obs: int,
+        n_vars: int,
+        n_components: int,
+        mean: torch.Tensor,
+        marginalize_z: bool,
+    ):
+        super().__init__(_PROBABILISTIC_PCA_PYRO_MODULE_NAME)
+
+        self.n_obs = n_obs
+        self.n_vars = n_vars
+        self.n_components = n_components
+        self.mean = mean
+        self.marginalize_z = marginalize_z
+
+        # model parameters
+        self.W = PyroParam(lambda: torch.randn((n_components, n_vars)))
+        self.sigma = PyroParam(
+            lambda: torch.tensor(1.0), constraint=constraints.positive
+        )
+
+    def forward(self, x: torch.Tensor):
+        """Forward pass."""
+        with pyro.plate("cells", size=self.n_obs, subsample_size=x.shape[0]):
+            if self.marginalize_z:
+                pyro.sample(
+                    "counts",
+                    dist.LowRankMultivariateNormal(
+                        loc=self.mean,
+                        cov_factor=self.W.T,
+                        cov_diag=self.sigma**2
+                        * torch.ones(self.n_vars, device=x.device),
+                    ),
+                    obs=x,
+                )
+            else:
+                z = pyro.sample(
+                    "z",
+                    dist.Normal(
+                        torch.zeros(self.n_components, device=x.device), 1
+                    ).to_event(1),
+                )
+                pyro.sample(
+                    "counts",
+                    dist.Normal(self.mean + z @ self.W, self.sigma).to_event(1),
+                    obs=x,
+                )
+
+
+class ProbabilisticPCAPyroGuide(PyroModule):
+    """
+    A PyroModule that serves as the guide for the ProbabilisticPCAPyroModule class.
+
+    Args:
+        n_obs: Number of observations.
+        n_vars: Number of input features.
+        n_components: Number of components to model.
+        mean: Mean of the input data.
+        marginalize_z: Marginalize latent variable z.
+    """
+
+    def __init__(
+        self,
+        n_obs: int,
+        n_vars: int,
+        n_components: int,
+        mean: torch.Tensor,
+        marginalize_z: bool,
+    ):
+        super().__init__(_PROBABILISTIC_PCA_PYRO_MODULE_NAME)
+
+        self.n_obs = n_obs
+        self.n_vars = n_vars
+        self.n_components = n_components
+        self.mean = mean
+        self.marginalize_z = marginalize_z
+
+        # guide parameters
+        if not self.marginalize_z:
+            self.L = PyroParam(lambda: torch.randn((n_vars, n_components)))
+            self.z_scale = PyroParam(
+                lambda: torch.ones(n_components), constraint=constraints.positive
+            )
+
+    def forward(self, x: torch.Tensor):
+        """Forward pass."""
+        if not self.marginalize_z:
+            with pyro.plate("cells", size=self.n_obs, subsample_size=x.shape[0]):
+                z_loc = (x - self.mean) @ self.L
+                pyro.sample("z", dist.Normal(z_loc, self.z_scale).to_event(1))
+
+
+class ProbabilisticPCAPyroModule(PyroBaseModuleClass):
+    """
+    Probabilistic PCA implemented in Pyro.
+
+    Args:
+        n_obs: Number of observations.
+        n_vars: Number of input features.
+        n_components: Number of components to model.
+        mean: Mean of the input data.
+        marginalize_z: Marginalize latent variable z.
+    """
+
+    def __init__(
+        self,
+        n_obs: int,
+        n_vars: int,
+        n_components: int,
+        mean: torch.Tensor = 0,
+        marginalize_z: bool = True,
+    ):
+        super().__init__()
+
+        self.n_obs = n_obs
+        self.n_vars = n_vars
+        self.n_components = n_components
+        self.mean = mean
+        self.marginalize_z = marginalize_z
+
+        self._model = ProbabilisticPCAPyroModel(
+            self.n_obs, self.n_vars, self.n_components, self.mean, self.marginalize_z
+        )
+        self._guide = ProbabilisticPCAPyroGuide(
+            self.n_obs, self.n_vars, self.n_components, self.mean, self.marginalize_z
+        )
+
+    @property
+    def model(self):
+        return self._model
+
+    @property
+    def guide(self):
+        return self._guide
+
+    @torch.inference_mode()
+    def get_latent_representation(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Return the latent representation for each cell.
+        """
+        L = self._guide.L
+        z_loc = (x - self.mean) @ L
+        return z_loc

--- a/scvid/module/_probabilisticpca.py
+++ b/scvid/module/_probabilisticpca.py
@@ -20,8 +20,8 @@ class ProbabilisticPCAPyroModule(PyroModule):
         ppca_flavor: Type of the PPCA model. Has to be one of `marginalize` or `diagonal_normal`
             or `multivariate_normal`.
         mean_g: Mean gene expression of the input data.
-        w: Scale of the random initialization of `W_kg` parameter.
-        s: Scale of the random initialization of `sigma` parameter.
+        w: Scale of the random initialization of the `W_kg` parameter.
+        s: Initialization value of the `sigma` parameter.
     """
 
     def __init__(
@@ -31,8 +31,8 @@ class ProbabilisticPCAPyroModule(PyroModule):
         k_components: int,
         ppca_flavor: str,
         mean_g: Optional[Union[float, int, torch.Tensor]] = None,
-        w: Optional[float] = None,
-        s: Optional[float] = None,
+        w: float = 1.0,
+        s: float = 1.0,
     ):
         super().__init__(_PROBABILISTIC_PCA_PYRO_MODULE_NAME)
 
@@ -53,12 +53,8 @@ class ProbabilisticPCAPyroModule(PyroModule):
 
         torch.manual_seed(0)
         # model parameters
-        w = 1 if w is None else w
-        s = 1 if s is None else s
         self.W_kg = PyroParam(lambda: w * torch.randn((k_components, g_genes)))
-        self.sigma = PyroParam(
-            lambda: torch.tensor(s), constraint=constraints.positive
-        )
+        self.sigma = PyroParam(lambda: torch.tensor(s), constraint=constraints.positive)
 
         # guide parameters
         if ppca_flavor == "marginalized":

--- a/test/test_ppca.py
+++ b/test/test_ppca.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pyro
+import pytest
+import scanpy as sc
+import torch
+from pyro import infer, optim
+
+from scvid.module import ProbabilisticPCAPyroModule
+
+n, p, k = 1000, 10, 2
+
+
+@pytest.fixture
+def x_np():
+    torch.manual_seed(1465)
+    z_nk = torch.randn(n, k)
+    w_kp = torch.randn(k, p)
+    sigma = 0.6
+    noise = sigma * torch.randn(n, p)
+    x_np = z_nk @ w_kp + noise
+    return x_np
+
+
+@pytest.mark.parametrize(
+    "marginalize", [False, True], ids=["unmarginalized", "marginalized"]
+)
+@pytest.mark.parametrize("minibatch", [False, True], ids=["fullbatch", "minibatch"])
+def test_probabilistic_pca(x_np, minibatch, marginalize):
+    x_mean = x_np.mean(axis=0)
+
+    pyro.clear_param_store()
+    ppca = ProbabilisticPCAPyroModule(
+        n_obs=n, n_vars=p, n_components=k, mean=x_mean, marginalize_z=marginalize
+    )
+    elbo = infer.Trace_ELBO()
+    adam = optim.Adam({"lr": 1e-2})
+    svi = infer.SVI(ppca.model, ppca.guide, adam, elbo)
+    for i in range(5000):
+        if minibatch:
+            batch_size = n // 2
+            ind = torch.randint(n, (batch_size,))
+            x_batch = x_np[ind]
+        else:
+            x_batch = x_np
+        svi.step(x_batch)
+
+    # expected var
+    expected_var = torch.var(x_np, axis=0).sum()
+
+    # actual var
+    W = pyro.param("probabilistic_pca.W").data
+    sigma = pyro.param("probabilistic_pca.sigma").data
+    actual_var = (torch.diag(W.T @ W) + sigma**2).sum()
+
+    np.testing.assert_allclose(expected_var, actual_var, rtol=0.05)
+
+    # check that the inferred z has std of 1
+    z = ppca.get_latent_representation(x_np)
+
+    np.testing.assert_allclose(z.std(), 1, rtol=0.04)

--- a/test/test_ppca.py
+++ b/test/test_ppca.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pyro
 import pytest
-import scanpy as sc
 import torch
 from pyro import infer, optim
 

--- a/test/test_ppca.py
+++ b/test/test_ppca.py
@@ -6,30 +6,34 @@ from pyro import infer, optim
 
 from scvid.module import ProbabilisticPCAPyroModule
 
-n, p, k = 1000, 10, 2
+n, g, k = 1000, 10, 2
 
 
 @pytest.fixture
-def x_np():
+def x_ng():
     torch.manual_seed(1465)
     z_nk = torch.randn(n, k)
-    w_kp = torch.randn(k, p)
+    w_kg = torch.randn(k, g)
     sigma = 0.6
-    noise = sigma * torch.randn(n, p)
-    x_np = z_nk @ w_kp + noise
-    return x_np
+    noise = sigma * torch.randn(n, g)
+    x_ng = z_nk @ w_kg + noise
+    return x_ng
 
 
 @pytest.mark.parametrize(
-    "marginalize", [False, True], ids=["unmarginalized", "marginalized"]
+    "ppca_flavor", ["marginalized", "diagonal_normal", "multivariate_normal"]
 )
+@pytest.mark.parametrize("learn_mean", [False, True])
 @pytest.mark.parametrize("minibatch", [False, True], ids=["fullbatch", "minibatch"])
-def test_probabilistic_pca(x_np, minibatch, marginalize):
-    x_mean = x_np.mean(axis=0)
+def test_probabilistic_pca(x_ng, minibatch, ppca_flavor, learn_mean):
+    if learn_mean:
+        x_mean_g = None
+    else:
+        x_mean_g = x_ng.mean(axis=0)
 
     pyro.clear_param_store()
     ppca = ProbabilisticPCAPyroModule(
-        n_obs=n, n_vars=p, n_components=k, mean=x_mean, marginalize_z=marginalize
+        n_cells=n, g_genes=g, k_components=k, ppca_flavor=ppca_flavor, mean_g=x_mean_g
     )
     elbo = infer.Trace_ELBO()
     adam = optim.Adam({"lr": 1e-2})
@@ -38,22 +42,22 @@ def test_probabilistic_pca(x_np, minibatch, marginalize):
         if minibatch:
             batch_size = n // 2
             ind = torch.randint(n, (batch_size,))
-            x_batch = x_np[ind]
+            x_batch = x_ng[ind]
         else:
-            x_batch = x_np
+            x_batch = x_ng
         svi.step(x_batch)
 
     # expected var
-    expected_var = torch.var(x_np, axis=0).sum()
+    expected_var = torch.var(x_ng, axis=0).sum()
 
     # actual var
-    W = pyro.param("probabilistic_pca.W").data
-    sigma = pyro.param("probabilistic_pca.sigma").data
-    actual_var = (torch.diag(W.T @ W) + sigma**2).sum()
+    W_kg = ppca.W_kg.data
+    sigma = ppca.sigma.data
+    actual_var = (torch.diag(W_kg.T @ W_kg) + sigma**2).sum()
 
     np.testing.assert_allclose(expected_var, actual_var, rtol=0.05)
 
     # check that the inferred z has std of 1
-    z = ppca.get_latent_representation(x_np)
+    z = ppca.get_latent_representation(x_ng)
 
     np.testing.assert_allclose(z.std(), 1, rtol=0.04)


### PR DESCRIPTION
Probabilistic PCA implemented in two versions:
- with z marginalized out (`marginalize_z=True` default flag) - seems to work better
- with z not marginalized out (`marginalize_z=False` flag)

Added a test that checks explained variance and that inferred `z` has std close to 1 for a test data.