### PR TITLE
Update merging rule for `OnePassMeanVarStd`

### DIFF
--- a/scvid/train/training_plan.py
+++ b/scvid/train/training_plan.py
@@ -110,3 +110,23 @@ class TrainingPlan(pl.LightningModule):
             set_epoch = getattr(dataset, "set_epoch", None)
             if callable(set_epoch):
                 set_epoch(self.current_epoch)
+
+    def on_train_start(self) -> None:
+        """
+        Calls the ``on_train_start`` method on the module.
+        If the module has ``on_train_start`` method defined, then
+        ``on_train_start`` must be called at the beginning of training.
+        """
+        on_train_start = getattr(self.module, "on_train_start", None)
+        if callable(on_train_start):
+            on_train_start(self.trainer)
+
+    def on_train_epoch_end(self) -> None:
+        """
+        Calls the ``on_epoch_end`` method on the module.
+        If the module has ``on_epoch_end`` method defined, then
+        ``on_epoch_end`` must be called at the end of every epoch.
+        """
+        on_epoch_end = getattr(self.module, "on_epoch_end", None)
+        if callable(on_epoch_end):
+            on_epoch_end(self.trainer)

--- a/test/test_onepass_mean_var_std.py
+++ b/test/test_onepass_mean_var_std.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import torch
 from anndata import AnnData
+from lightning.pytorch.strategies import DDPStrategy
 
 from scvid.callbacks import ModuleCheckpoint
 from scvid.data import (
@@ -126,11 +127,13 @@ def test_onepass_mean_var_std_iterable_dataset_multi_device(
     # fit
     model = OnePassMeanVarStd(g_genes=dadc.n_vars, transform=transform)
     training_plan = TrainingPlan(model)
+    strategy = DDPStrategy(broadcast_buffers=False) if devices > 1 else "auto"
     trainer = pl.Trainer(
         barebones=True,
         accelerator="cpu",
         devices=devices,
         max_epochs=1,  # one pass
+        strategy=strategy,  # type: ignore[arg-type]
     )
     trainer.fit(training_plan, train_dataloaders=data_loader)
 


### PR DESCRIPTION
Update the merging rule for `OnePassMeanVarStd` to make it more efficient:
1. Perform merging at the end of the epoch, not every mini-batch
2. Merge only summary statistics, no need to gather entire mini-batches